### PR TITLE
Remove Algolia search and GA tag

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -174,18 +174,6 @@ module.exports = {
       },
       copyright: `Copyright © ${new Date().getFullYear()} Weaveworks`,
     },
-    algolia: {
-      appId: "Z1KEXCDHZE",
-      apiKey: process.env.ALGOLIA_API_KEY,
-      indexName: "weave",
-      // Needed to handle the different versions of docs
-      contextualSearch: true,
-
-      // Optional: Algolia search parameters
-      // searchParameters: {
-      //   facetFilters: ['type:content']
-      // },
-    },
   },
   scripts: [
     {
@@ -219,10 +207,6 @@ module.exports = {
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
-        },
-        gtag: {
-          trackingID: process.env.GA_KEY,
-          anonymizeIP: true, // Should IPs be anonymized?
         },
         sitemap: {
             changefreq: 'weekly',


### PR DESCRIPTION
(The Algolia API key and Google Analytics tag have been removed)

The https://docs.microscaler.com/ is currently deployed based on a build from this config

Spin configuration is quite minimal, I'm using Fermyon Cloud to deploy it for now at least

All the configuration I used to republish it lives at: https://github.com/microscaler/gitops-docs